### PR TITLE
Fixed double-free issue with non-square grids.

### DIFF
--- a/include/CombBLAS/CommGrid.h
+++ b/include/CombBLAS/CommGrid.h
@@ -51,7 +51,9 @@ public:
 		MPI_Comm_free(&commWorld);
 		MPI_Comm_free(&rowWorld);
 		MPI_Comm_free(&colWorld);
-		if(diagWorld != MPI_COMM_NULL) MPI_Comm_free(&diagWorld);
+		if(grrows == grcols) {
+			if(diagWorld != MPI_COMM_NULL) MPI_Comm_free(&diagWorld);
+		}
 	}
 	CommGrid (const CommGrid & rhs): grrows(rhs.grrows), grcols(rhs.grcols),
 			myprocrow(rhs.myprocrow), myproccol(rhs.myproccol), myrank(rhs.myrank) // copy constructor

--- a/src/CommGrid.cpp
+++ b/src/CommGrid.cpp
@@ -78,8 +78,8 @@ void CommGrid::CreateDiagWorld()
 {
 	if(grrows != grcols)	
 	{
-		cout << "The grid is not square... !" << endl;
-		cout << "Returning diagworld to everyone instead of the diagonal" << endl;
+		//cout << "The grid is not square... !" << endl;
+		//cout << "Returning diagworld to everyone instead of the diagonal" << endl;
 		diagWorld = commWorld;
 		return;
 	}


### PR DESCRIPTION
When the process grid is non-square., diagWorld is set as the entire communicator world, which leads to a double free when the communicator grid is destroyed. This commit fixes the double-free issue. 

This commit also comments out the warning about returning the entire world as the diagonal world for non-square communication grid (every rank produces this warning for a non-square grid, which be annoying. Maybe a better way to do this would be to only have process 0 report this warning? This would need a call to MPI_Comm_Rank, but I just commented it out. Happy to fix this so the warning is no longer silent.