### PR TITLE
Summa overlap fix

### DIFF
--- a/ReleaseTests/MultTest.cpp
+++ b/ReleaseTests/MultTest.cpp
@@ -179,6 +179,16 @@ int main(int argc, char* argv[])
 		{
 			SpParHelper::Print("ERROR in double buffered multiplication, go fix it!\n");	
 		}
+
+		C = Mult_AnXBn_Overlap<PTDOUBLEDOUBLE, double, PSpMat<double>::DCCols >(A,B);
+		if (CControl == C)
+		{
+			SpParHelper::Print("Overlapped multiplication working correctly\n");	
+		}
+		else
+		{
+			SpParHelper::Print("ERROR in overlapped multiplication, go fix it!\n");	
+		}
 #endif
 		OptBuf<int32_t, int64_t> optbuf;
 		PSpMat<bool>::MPI_DCCols ABool(A);


### PR DESCRIPTION
Fixes [Issue# 32](https://github.com/PASSIONLab/CombBLAS/issues/32)

Communication computation overlap is achieved in each SUMMA stage using asynchronous broadcast calls and OpenMP tasks. In each SUMMA stage, four asychronous broadcasts are called; then split the OpenMP threads into two tasks - one for continuous probing to progress communication while rest to drive the local-SpGEMM. MultiwayMerge is used when all SUMMA stages are finished as usual.