### PR TITLE
Use std for CSC

### DIFF
--- a/include/CombBLAS/MPIType.h
+++ b/include/CombBLAS/MPIType.h
@@ -131,6 +131,7 @@ template<> MPI_Datatype MPIType< float >( void );
 template<> MPI_Datatype MPIType< double >( void );
 template<> MPI_Datatype MPIType< long double >( void );
 template<> MPI_Datatype MPIType< bool >( void );
+template<> MPI_Datatype MPIType< long long>(void);
 
 
 

--- a/include/CombBLAS/csc.cpp
+++ b/include/CombBLAS/csc.cpp
@@ -237,7 +237,7 @@ Csc<IT, NT>::Split (Csc<IT, NT> *	&A,
 		B = new Csc<IT, NT>(nz - jc[cut], n - cut);
 		std::copy(jc + cut, jc + n + 1, B->jc);
         auto jccut = jc[cut];
-		transform(B->jc, B->jc + (n - cut + 1), B->jc,
+		std::transform(B->jc, B->jc + (n - cut + 1), B->jc,
 		[jccut](IT val) { return val - jccut; }
 		);
 		std::copy(ir + jc[cut], ir + nz, B->ir);

--- a/src/MPIType.cpp
+++ b/src/MPIType.cpp
@@ -85,5 +85,9 @@ template<> MPI_Datatype MPIType< bool >( void )
 {
 	return MPI_BYTE;  // usually  #define MPI_BOOL MPI_BYTE anyway
 };
+template<> MPI_Datatype MPIType< long long>( void )
+{
+	return MPI_LONG_LONG;
+};
 
 }


### PR DESCRIPTION
Small change to explicitly use `std::transform`, allowing csc to compile